### PR TITLE
Add QAM2048 and QAM128 Channel Modes

### DIFF
--- a/tg3442de_exporter/docsis_status_extractor.py
+++ b/tg3442de_exporter/docsis_status_extractor.py
@@ -26,8 +26,10 @@ class ChannelType(Enum):
 
 class ChannelModulation(Enum):
     QAM4096 = '4096QAM'
+    QAM2048 = '2048QAM'
     QAM1024 = '1024QAM'
     QAM256  = '256QAM'
+    QAM128  = '128QAM'
     QAM64   = '64QAM'
     QAM16   = '16QAM'
     QPSK    = 'QPSK'


### PR DESCRIPTION
This PR adds missing channel modes used by Vodafone West